### PR TITLE
Please add libtest-script-run-perl to the build dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: feedgnuplot
 Section: perl
 Priority: optional
-Build-Depends: debhelper (>= 7)
+Build-Depends: debhelper (>= 7), libtest-script-run-perl
 Build-Depends-Indep: perl
 Maintainer: Dima Kogan <dima@secretsauce.net>
 Standards-Version: 3.9.2


### PR DESCRIPTION
I didn’t have it installed and building the package failed, because the test was not possible to run.

Cheers,
Hermann
