### PR TITLE
Fix for "Use of implicit split to @_ is deprecated at /d/home/coreyp/bin...

### DIFF
--- a/bin/feedgnuplot
+++ b/bin/feedgnuplot
@@ -371,7 +371,7 @@ sub interpretCommandline
     $options{timefmt} =~ s/^\s*//;
     $options{timefmt} =~ s/\s*$//;
 
-    my $Nfields = scalar split( ' ', $options{timefmt});
+    my $Nfields = () = split /\s+/, $options{timefmt}, -1;
     $options{timefmt_Ncols} = $Nfields;
 
     # make sure --xlen is an integer. With a timefmt xlen goes through strptime


### PR DESCRIPTION
.../feedgnuplot line 377"
